### PR TITLE
Fix: 1G alignment that seems to fix corruption errors in YCSB + LevelDB

### DIFF
--- a/scripts/set_nvdimm.sh
+++ b/scripts/set_nvdimm.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 sudo ndctl disable-namespace all
 sudo ndctl destroy-namespace all --force
-sudo ndctl create-namespace -m devdax 
+sudo ndctl create-namespace -m devdax -a 1G


### PR DESCRIPTION
ctFS became much more stable after enforcing 1G alignment of the namespace. It allows me to run YCSB + LevelDB without corruption errors